### PR TITLE
Set androidXBrowser to v1.5.0

### DIFF
--- a/MagicBareRnExample/android/build.gradle
+++ b/MagicBareRnExample/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
+        androidXBrowser = "1.5.0"
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
- Fixes [this error](https://stackoverflow.com/questions/68207334/getting-error-while-running-react-native-run-android) when running React Native Bare in the Android environment 